### PR TITLE
Correcting index.html path for two extensions.

### DIFF
--- a/pkg/extensions/markdown-pro-editor.yaml
+++ b/pkg/extensions/markdown-pro-editor.yaml
@@ -2,7 +2,7 @@
 id: xyz.notes.markdown-pro-editor
 npm: sn-markdown-pro-editor
 repo_url: https://github.com/standardnotes/markdown-pro.git
-index: index.html
+index: dist/index.html
 
 name: Markdown Pro Editor
 content_type: SN|Component

--- a/pkg/extensions/plus-editor.yaml
+++ b/pkg/extensions/plus-editor.yaml
@@ -2,7 +2,7 @@
 id: xyz.notes.plus-editor
 npm: sn-plus-editor
 repo_url: https://github.com/standardnotes/plus-editor.git
-index: index.html
+index: dist/index.html
 
 name: Plus Editor
 content_type: SN|Component


### PR DESCRIPTION
Apparently, Markdown Pro and Plus editors removed ext.json which originally pointed to dist/index.html. Without it it apps fall back to nonexistent index.html, breaking extensions. 

Judging by `dist/index.html` in other extensions (e.g. Bold editor) this isn't new.