### PR TITLE
Fixing more extensions.

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -22,7 +22,7 @@ import (
 var (
 	validUntil       = time.Date(2030, 0, 0, 0, 0, 0, 0, time.Local)
 	snExtRepo        = "https://github.com/sn-extensions"
-	regexpPackgeHash = regexp.MustCompile(`\/[0-9a-f]+\b`)
+	regexpPackgeHash = regexp.MustCompile(`\/[0-9a-f]+\/`)
 
 	//go:embed web/*
 	webFS embed.FS
@@ -130,7 +130,7 @@ func (c *Controller) ServeExtensionIndex(w http.ResponseWriter, r *http.Request)
 func (c *Controller) ServeExtension(w http.ResponseWriter, r *http.Request) {
 	filePath := path.Join(
 		c.ReposDir,
-		regexpPackgeHash.ReplaceAllString(r.URL.Path, ""),
+		regexpPackgeHash.ReplaceAllString(r.URL.Path, "/"),
 	)
 	// would have preferred to use http.ServeFile or http.Dir etc.
 	// but they seem to 301 requests for /index.html to /, which the

--- a/pkg/extensions/vs-code-theme.yaml
+++ b/pkg/extensions/vs-code-theme.yaml
@@ -1,7 +1,7 @@
 ---
 id: io.github.hyphone.sn-theme-vscode
 repo_url: https://github.com/hyphone/sn-theme-vscode.git
-index: dist/dist.css
+index: dist.css
 
 name: VS Code Theme
 content_type: SN|Theme


### PR DESCRIPTION
Fixes https://github.com/sentriz/standardnotes-extensions/issues/4.

Fixed path is due to changes in extension. Regex was unintentionally catching `de` in `de.danielilin.evernote-dark-theme` and such.